### PR TITLE
Correct  "ose-metrics-schema-installer" to "metrics-schema-installer"

### DIFF
--- a/install/disconnected_install.adoc
+++ b/install/disconnected_install.adoc
@@ -254,13 +254,13 @@ $ docker pull registry.redhat.io/openshift3/metrics-cassandra:<tag>
 $ docker pull registry.redhat.io/openshift3/metrics-hawkular-metrics:<tag>
 $ docker pull registry.redhat.io/openshift3/metrics-hawkular-openshift-agent:<tag>
 $ docker pull registry.redhat.io/openshift3/metrics-heapster:<tag>
+$ docker pull registry.redhat.io/openshift3/metrics-schema-installer:<tag>
 $ docker pull registry.redhat.io/openshift3/oauth-proxy:<tag>
 $ docker pull registry.redhat.io/openshift3/ose-logging-curator5:<tag>
 $ docker pull registry.redhat.io/openshift3/ose-logging-elasticsearch5:<tag>
 $ docker pull registry.redhat.io/openshift3/ose-logging-eventrouter:<tag>
 $ docker pull registry.redhat.io/openshift3/ose-logging-fluentd:<tag>
 $ docker pull registry.redhat.io/openshift3/ose-logging-kibana5:<tag>
-$ docker pull registry.redhat.io/openshift3/ose-metrics-schema-installer:<tag>
 $ docker pull registry.redhat.io/openshift3/prometheus:<tag>
 $ docker pull registry.redhat.io/openshift3/prometheus-alert-buffer:<tag>
 $ docker pull registry.redhat.io/openshift3/prometheus-alertmanager:<tag>
@@ -442,13 +442,13 @@ $ docker save -o ose3-optional-imags.tar \
     registry.redhat.io/openshift3/metrics-hawkular-metrics \
     registry.redhat.io/openshift3/metrics-hawkular-openshift-agent \
     registry.redhat.io/openshift3/metrics-heapster \
+    registry.redhat.io/openshift3/metrics-schema-installer \
     registry.redhat.io/openshift3/oauth-proxy \
     registry.redhat.io/openshift3/ose-logging-curator5 \
     registry.redhat.io/openshift3/ose-logging-elasticsearch5 \
     registry.redhat.io/openshift3/ose-logging-eventrouter \
     registry.redhat.io/openshift3/ose-logging-fluentd \
     registry.redhat.io/openshift3/ose-logging-kibana5 \
-    registry.redhat.io/openshift3/ose-metrics-schema-installer \
     registry.redhat.io/openshift3/prometheus \
     registry.redhat.io/openshift3/prometheus-alert-buffer \
     registry.redhat.io/openshift3/prometheus-alertmanager \


### PR DESCRIPTION
* Fix the BZ:  [Image referenced to deploy hawkular-metricsis not alligned with documentation image name ("ose-" prefix)](https://bugzilla.redhat.com/show_bug.cgi?id=1650126)

* Description
The `metrics-schema-installer` image should be pulled instead of `ose-metrics-schema-installer` during metrics installation. (in reality `metrics-schema-installer` can be pulled from `registry.redhat.io`)
And ansible `openshift_metrics` role does not implement to use `ose-metrics-schema-installer` as follows. So `metrics-schema-installer` is correct image name likewise other metrics images without `ose-` prefix.

~~~
openshift_metrics_cassandra_image: "{{ l_os_registry_url | regex_replace(l_openshift_logging_search | regex_escape, 'metrics-cassandra') }}"
openshift_metrics_hawkular_agent_image: "{{ l_os_registry_url | regex_replace(l_openshift_logging_search | regex_escape, 'metrics-hawkular-openshift-agent') }}"
openshift_metrics_hawkular_metrics_image: "{{ l_os_registry_url | regex_replace(l_openshift_logging_search | regex_escape, 'metrics-hawkular-metrics') }}"
openshift_metrics_schema_installer_image: "{{ l_os_registry_url | regex_replace(l_openshift_logging_search | regex_escape, 'metrics-schema-installer') }}"
openshift_metrics_heapster_image: "{{ l_os_registry_url | regex_replace(l_openshift_logging_search | regex_escape, 'metrics-heapster') }}"
~~~